### PR TITLE
Reporter: extend log to include summary of tests

### DIFF
--- a/reporter/index.ts
+++ b/reporter/index.ts
@@ -1,5 +1,18 @@
 import { Reporter, DefaultReporter, Config, Context, AggregatedResult } from '@jest/reporters';
 
+// TODO - Bummer can't find types with PNP?  AggregatedResult["testResult"] 
+function buildSummary(results: AggregatedResult) {
+  let summary: string[] = [];
+  results.testResults.forEach(({ testResults }: any) => 
+    testResults.forEach((result: any) => 
+      summary.push(`${result.status === 'passed' ? '✓' : '✕'} ${result.fullName}`
+      )
+    )
+  );
+
+  return `START_SUMMARY\n${summary.join('\n')}\nEND_SUMMARY`;
+}
+
 export default class G2iReporter implements Reporter {
   #globalConfig: Config.GlobalConfig;
   #options: Record<string, unknown>;
@@ -10,7 +23,8 @@ export default class G2iReporter implements Reporter {
   }
 
   onRunStart(): void {}
-  onRunComplete(contexts: Set<Context>, results: AggregatedResult) {
+  onRunComplete(_contexts: Set<Context>, results: AggregatedResult) {
+    console.log(buildSummary(results));
     console.log(`result=${results.numPassedTests / results.numTotalTests}`)
   }
   getLastError(): void {}

--- a/reporter/index.ts
+++ b/reporter/index.ts
@@ -1,10 +1,9 @@
 import { Reporter, DefaultReporter, Config, Context, AggregatedResult } from '@jest/reporters';
 
-// TODO - Bummer can't find types with PNP?  AggregatedResult["testResult"] 
 function buildSummary(results: AggregatedResult) {
   let summary: string[] = [];
-  results.testResults.forEach(({ testResults }: any) => 
-    testResults.forEach((result: any) => 
+  results.testResults.forEach(({ testResults }) => 
+    testResults.forEach((result) => 
       summary.push(`${result.status === 'passed' ? '✓' : '✕'} ${result.fullName}`
       )
     )


### PR DESCRIPTION
Include summary of tests. 

@totallymike I spent 5 minutes trying to figure out why the types aren't found, this seems to be an issue with PNP, can you look>? 